### PR TITLE
refactor(decoratorFactory): fix issues with getters and setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,23 @@ decorators are applied at the instance level.
 - `after`
 - `before`
 
+__Note__: Due to the nature of how instance decorators work they MUST be processed
+after all prototype decorators in the decorator chain. There isn't a graceful way
+to get around this currently. More or less instance decorators are kind of a hack and experimental.
+
+```javascript
+class Person {
+
+  @curry(2) // <= prototype decorator
+  @debounce(100) // <= instance decorator
+  getName() {} //=> Throws an error. (╯°□°）╯︵ ┻━┻
+
+  @debounce(100) // <= instance decorator
+  @curry(2) // <= prototype decorator
+  getName2() {} //=> All is well :)
+}
+```
+
 ### Getters and Setters
 
 Most decorators can be applied directly to getter and setter methods.
@@ -234,12 +251,12 @@ function alwaysArray(value) {
 class Person {
   constructor() {}
 
-  @once
+  @once.get
   get names() {
     return this.nameList.join(' ');
   }
 
-  @compose(alwaysArray)
+  @compose.set(alwaysArray)
   set names(names) {
     this.nameList = names;
   }
@@ -252,6 +269,19 @@ person.names = undefined; //=> []
 person.names = 'Joe'; //=> ['Joe']
 person.names = ['Jim']; //=> ['Jim']
 ```
+
+#### What's with the `.get`?
+
+The decorator has no way to tell whether you are applying the decorator to the getter or setter (when both are provided).
+The decorator just receives the descriptor which has both values provided and no way to distinguish which one you are provided
+which decorator to.
+
+`@once.get` uses a form of the decorator that explicitly applies to the getter method.
+`@once.set` uses a form of the decorator that explicitly applies to the setter method.
+
+#### Can I use decorators on getters/setters without these?
+
+Use at you're own risk...
 
 ### Bind
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lodash-decorators",
   "author": "Steven Sojka <steelsojka@gmail.com>",
   "description": "A collection of decorators using lodash at it's core.",
-  "version": "0.4.13",
+  "version": "1.0.0",
   "engines": {
     "node": ">=0.12.0"
   },

--- a/src/bind/bindAll.js
+++ b/src/bind/bindAll.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import bindAllClassMethods from '../utils/bindAllClassMethods';
+import bindAllClassMethods from './bindAllClassMethods';
 import flatten from 'lodash/array/flatten';
 import assignAll, { FUNCTION_PROPERTY_EXCLUDES } from '../utils/assignAll';
 import wrapConstructor from '../utils/wrapConstructor';

--- a/src/bind/bindMap.js
+++ b/src/bind/bindMap.js
@@ -1,0 +1,5 @@
+'use strict';
+
+import CompositeKeyWeakMap from '../utils/CompositeKeyWeakMap';
+
+export default new CompositeKeyWeakMap();

--- a/src/decoratorFactory.js
+++ b/src/decoratorFactory.js
@@ -3,19 +3,28 @@
 import forOwn from 'lodash/object/forOwn';
 import isFunction from 'lodash/lang/isFunction';
 import partial from 'lodash/function/partial';
+import identity from 'lodash/utility/identity';
+import values from 'lodash/object/values';
+import assign from 'lodash/object/assign';
 
+import bindMap from './bind/bindMap';
 import CompositeKeyWeakMap from './utils/CompositeKeyWeakMap';
 import copyMetaData from './utils/copyMetaData';
 import Applicator from './Applicator';
+import log from './utils/log';
+import normalizeExport from './utils/normalizeExport';
 
 const { applicators } = Applicator;
+const instanceMethodMap = new CompositeKeyWeakMap();
 
-export const decorateTargets = {
+export const decoratorTargets = {
   GET: 'get',
   SET: 'set',
   VALUE: 'value',
   INITIALIZER: 'initializer'
 };
+
+export const decoratorTargetSet = new Set(values(decoratorTargets));
 
 /**
  * Gets a decorators target type.
@@ -23,92 +32,207 @@ export const decorateTargets = {
  * @param {Object} target The decorator target.
  * @param {String} name The property name.
  * @param {Object} descriptor The property descriptor.
- * @param {CompositeKeyWeakMap} getterSetterMap The getter/setter map
- *   for the decorator. This is needed to check whether the getter or setter
- *   has been set.
  * @returns {String} A decorator target type.
  */
-export function getDecoratorTarget(target, name, descriptor, getterSetterMap) {
-  if (descriptor.get && !getterSetterMap.has([target, name, 'get'])) {
-    return decorateTargets.GET;
-  } else if (descriptor.set && !getterSetterMap.has([target, name, 'set'])) {
-    return decorateTargets.SET;
+export function getDecoratorTarget(target, name, descriptor) {
+  if (descriptor.get) {
+    return decoratorTargets.GET;
+  } else if (descriptor.set) {
+    return decoratorTargets.SET;
   } else if (descriptor.value) {
-    return decorateTargets.VALUE;
+    return decoratorTargets.VALUE;
   } else if (descriptor.initializer) {
-    return decorateTargets.INITIALIZER;
+    return decoratorTargets.INITIALIZER;
   }
 
-  throw new ReferenceError('Invalid decorator target.');
+  throw new ReferenceError(log('Invalid decorator target.'));
 }
 
-/**
- * Creates a decorator that uses an applicator to wrap a transform function.
- *
- * @param {Function} method The method that will __wrap__ the function being decorated.
- * @param {Function} [applicator=applicators.pre] The applicator function to apply the __method__ with.
- * @returns {Function} The decorator function or decorator wrapper function.
- */
-export function createDecorator(method, applicator = applicators.pre) {
-  const getterSetterMap = new CompositeKeyWeakMap();
+export const createDecorator = createDecoratorFactory(
+  createDecoratorApplicator(getDecoratorTarget),
+  partial(wrapDecoratorWithAccessors, false)
+);
 
-  return applicator === applicators.single ? wrapper() : wrapper;
+export const createGetterDecorator = createDecoratorFactory(
+  createDecoratorApplicator(decoratorTargets.GET)
+);
 
-  function wrapper(...args) {
-    return function decorator(target, name, descriptor) {
-      const decoratorTarget = getDecoratorTarget(target, name, descriptor, getterSetterMap);
-      const preTransform = descriptor[decoratorTarget];
+export const createSetterDecorator = createDecoratorFactory(
+  createDecoratorApplicator(decoratorTargets.SET)
+);
 
-      descriptor[decoratorTarget] = Applicator.invoke(applicator, method, target, preTransform, ...args);
-      copyMetaData(descriptor[decoratorTarget], preTransform);
+export const createInstanceDecorator = createDecoratorFactory(
+  createInstanceDecoratorApplicator(getDecoratorTarget),
+  partial(wrapDecoratorWithAccessors, true),
+  true
+);
 
-      if (decoratorTarget === decorateTargets.SET || decoratorTarget === decorateTargets.GET) {
-        getterSetterMap.set([target, name, decoratorTarget], descriptor[decoratorTarget]);
-      }
+export const createInstanceSetterDecorator = createDecoratorFactory(
+  createInstanceDecoratorApplicator(decoratorTargets.SET),
+  identity,
+  true
+);
 
-      return descriptor;
-    };
-  }
+export const createInstanceGetterDecorator = createDecoratorFactory(
+  createInstanceDecoratorApplicator(decoratorTargets.GET),
+  identity,
+  true
+);
+
+function throwInstanceError() {
+  // Instance decorators need to be processed last in the chain, proceding prototype decorators.
+  // Any prototype decorator processed after an instance decorator will get the getter proxy
+  // instead of the function
+  throw new Error(log('Instance decorators need to come after prototype decorators!'));
 }
 
-/**
- * Creates an instance decorator that uses an applicator to wrap a transform function.
- * This has different behaviour than a decorator that is applied to a class as a whole.
- *
- * This uses a WeakMap to keep track of instances and methods.
- *
- * @param {Function} method The method that will __wrap__ the function being decorated.
- * @param {Function} [applicator=applicators.pre] The applicator function to apply the __method__ with.
- * @returns {Function} The decorator function or decorator wrapper function.
- */
-export function createInstanceDecorator(method, applicator = applicators.pre) {
-  const objectMap = new CompositeKeyWeakMap();
-  const getterSetterMap = new CompositeKeyWeakMap();
+function resolveTargetName(targetName, ...args) {
+  return isFunction(targetName) ? targetName(...args) : targetName;
+}
 
-  return applicator === applicators.single ? wrapper() : wrapper;
+function createDecoratorApplicator(forcedTargetName) {
+  return function decoratorApplicator(target, name, descriptor, method, applicator, instanceMap, ...args) {
+    let targetName = resolveTargetName(forcedTargetName, target, name, descriptor);
 
-  function wrapper(...args) {
-    return function decorator(target, name, descriptor) {
-      const decoratorTarget = getDecoratorTarget(target, name, descriptor, getterSetterMap);
-      const preTransform = descriptor[decoratorTarget];
+    if (instanceMethodMap.has([target, name])) {
+      throwInstanceError();
+    }
 
-      descriptor[decoratorTarget] = copyMetaData(partial(instanceDecoratorWrapper, preTransform), preTransform);
+    if (decoratorTargetSet.has(targetName)) {
+      const targetMethod = descriptor[targetName];
 
-      if (decoratorTarget === decorateTargets.SET || decoratorTarget === decorateTargets.GET) {
-        getterSetterMap.set([target, name, decoratorTarget], descriptor[decoratorTarget]);
-      }
+      descriptor[targetName] = Applicator.invoke(applicator, method, target, targetMethod, ...args);
+      copyMetaData(descriptor[targetName], targetMethod);
+    }
 
-      return descriptor;
+    return descriptor;
+  };
+}
 
-      function instanceDecoratorWrapper(toWrap, ...methodArgs) {
-        if (!objectMap.has([this, toWrap])) {
-          objectMap.set([this, toWrap], Applicator.invoke(applicator, method, this, toWrap, ...args));
+function createInstanceDecoratorApplicator(forcedTargetName) {
+  return function instanceDecoratorApplicator(target, name, descriptor, method, applicator, instanceMap, ...args) {
+    let targetName = resolveTargetName(forcedTargetName, target, name, descriptor);
+    let targetMethod = descriptor[targetName];
+    let methodMapKey = [target, name];
+    let hasInstanceMap = instanceMethodMap.has(methodMapKey);
+
+    // Used as a unique symbol for this decorator/method combination.
+    // We can then tell where this decorator is in the chain.
+    let token = Symbol();
+
+    switch (targetName) {
+      // We are assuming at this point this is a method being decorated and not a getter or setter.
+      case decoratorTargets.VALUE:
+        if (!hasInstanceMap) {
+          instanceMethodMap.set(methodMapKey, [token]);
+          hasInstanceMap = true;
         }
 
-        const fn = objectMap.get([this, toWrap]);
+        delete descriptor.value;
+        delete descriptor.writable;
+        descriptor.get = createGetterProxy();
+        descriptor.set = createBaseValueSetter(descriptor);
+        break;
+      case decoratorTargets.GET:
+        if (hasInstanceMap) {
+          instanceMethodMap.get(methodMapKey).unshift(token);
+        }
 
-        return fn.apply(this, methodArgs);
+        descriptor.get = createGetterProxy();
+
+        // If there is no setter create one to avoid errors
+        if (!descriptor.set) {
+          descriptor.set = identity;
+        }
+
+        break;
+      case decoratorTargets.SET:
+        descriptor.set = createSetterProxy();
+
+        if (!descriptor.get) {
+          descriptor.get = identity;
+        }
+
+        break;
+    }
+
+    return descriptor;
+
+    // If the user assigns a value to a method with a instance decorator,
+    // the value for the decorator will be overwritten. You will loose the
+    // decorator chain, which would be the expected behaviour.
+    function createBaseValueSetter({enumerable, writable, configurable}) {
+      return function baseValueSetter(value) {
+        Object.defineProperty(this, name, {
+          value,
+          configurable,
+          writable,
+          enumerable
+        });
+      };
+    }
+
+    function createSetterProxy() {
+      return copyMetaData(function instanceSetterProxy(value) {
+        const keys = [this, decoratorTargets.SET, targetMethod];
+
+        if (!instanceMap.has(keys)) {
+          instanceMap.set(keys, Applicator.invoke(applicator, method, this, targetMethod, ...args));
+        }
+
+        const setter = instanceMap.get(keys);
+
+        return setter.call(this, value);
+      });
+    }
+
+    // A proxy that gets the instances wrapped function and either returns it
+    // or executes it. If the decorator is the first in the chain to execute
+    // and was applied to a method and not a getter, then it will return the
+    // function and all subsequent functions will execute.
+    function createGetterProxy() {
+      return copyMetaData(instanceGetterProxy, targetMethod);
+
+      function instanceGetterProxy() {
+        const keys = [this, decoratorTargets.GET, targetMethod];
+        let invoke = true;
+
+        if (hasInstanceMap) {
+          invoke = instanceMethodMap.get(methodMapKey).indexOf(token) !== 0;
+        }
+
+        if (!instanceMap.has(keys)) {
+          instanceMap.set(keys, Applicator.invoke(applicator, method, this, targetMethod, ...args));
+        }
+
+        const fn = instanceMap.get(keys);
+
+        return invoke ? fn.apply(this, arguments) : bindMap.has([this, name]) ? fn.bind(this) : fn;
       }
-    };
-  }
+    }
+  };
+}
+
+function createDecoratorFactory(executeFn, modifierFn = identity, createInstanceMap = false) {
+  return function createDecorator(method, applicator = applicators.pre) {
+    let instanceMap = createInstanceMap ? new CompositeKeyWeakMap() : null;
+    let decorator = applicator === applicators.single ? wrapper() : wrapper;
+
+    return modifierFn(decorator, method, applicator);
+
+    function wrapper(...args) {
+      return function decorator(target, name, descriptor) {
+        return executeFn(target, name, descriptor, method, applicator, instanceMap, ...args);
+      };
+    }
+  };
+}
+
+function wrapDecoratorWithAccessors(instance, decorator, method, applicator, ...args) {
+  let accessors = {
+    get: instance ? createInstanceGetterDecorator(method, applicator) : createGetterDecorator(method, applicator),
+    set: instance ? createInstanceSetterDecorator(method, applicator) : createSetterDecorator(method, applicator)
+  };
+
+  return assign(decorator, normalizeExport(accessors));
 }

--- a/test/instance.spec.js
+++ b/test/instance.spec.js
@@ -3,7 +3,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import _ from 'lodash';
-import { After, Once, Memoize } from '../src';
+import { Debounce, After, Once, Memoize } from '../src';
 
 describe('instance decorators', () => {
   let spy, person, person2, actual, getSpy, setSpy;
@@ -25,14 +25,23 @@ describe('instance decorators', () => {
         return 123;
       }
 
+      @Debounce(50)
+      fn2() {
+      }
+
+      @Debounce(100)
       @After(2)
-      @Once
+      fn3() {
+      }
+
+      @After.get(2)
+      @Once.get
       get name() {
         getSpy();
         return '';
       }
 
-      @Once
+      @Once.set
       set name(name) {
         setSpy(name);
       }
@@ -44,6 +53,16 @@ describe('instance decorators', () => {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  describe('when returning the function', () => {
+    it('should contain any metadata', () => {
+      expect(person.fn2.cancel).to.be.a.func;
+    });
+
+    it('should transfer metadata', () => {
+      expect(person.fn3.cancel).to.be.a.func;
+    });
   });
 
   describe('when using a function', () => {
@@ -68,6 +87,14 @@ describe('instance decorators', () => {
       expect(spy).to.have.been.calledTwice;
       expect(spy).to.have.been.calledWith(333);
       expect(spy).to.have.been.calledWith(444);
+    });
+
+    it('should reassign the function', () => {
+      let fn = () => null;
+
+      person.fn = fn;
+
+      expect(person.fn).to.equal(fn);
     });
   });
 


### PR DESCRIPTION
BREAKING CHANGE

Getters/setters have to use the explicit `get` and `set` decorators
appended onto the standard method decorators.

```
// Standard methods
@Debounce(100)
fn() {}

// Getters
@Debounce.get(100)
get name() {}

// Setters
@Debounce.set(100)
set name() {}
```
