### PR TITLE
Copy metadata to bound function getter.

### DIFF
--- a/src/decoratorFactory.js
+++ b/src/decoratorFactory.js
@@ -207,7 +207,7 @@ function createInstanceDecoratorApplicator(forcedTargetName) {
 
         const fn = instanceMap.get(keys);
 
-        return invoke ? fn.apply(this, arguments) : bindMap.has([this, name]) ? fn.bind(this) : fn;
+        return invoke ? fn.apply(this, arguments) : bindMap.has([this, name]) ? copyMetaData(fn.bind(this), fn) : fn;
       }
     }
   };


### PR DESCRIPTION
If the function that's being wrapped is a getter then the correct metadata is assigned to it. This allows for using method instance calls such as debounce's `.cancel()` when the method is bound.
