### PR TITLE
make lodash package as a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Decorators using lodash functions. View the [API docs](https://steelsojka.github
 
 ## Install
 
-`npm install --save lodash-decorators`
+`npm install --save lodash lodash-decorators`
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -60,8 +60,10 @@
     "ts-node": "^3.0.2",
     "typescript": "^2.2.2"
   },
+  "peerDependencies": {
+    "lodash": "4.x"
+  },
   "dependencies": {
-    "lodash": "^4.0.0",
     "tslib": "^1.6.1"
   }
 }


### PR DESCRIPTION
First of all, thank you for your work (especially for the `v4` !)

I'd like to suggest make `lodash` package as a [peerDependency](https://nodejs.org/en/blog/npm/peer-dependencies/).

Like other plugin packages (such as `chai-xxx`), It'd be the better practice I think.

