### PR TITLE
feat(*): add support for Angular 2+ in AOT mode

### DIFF
--- a/src/after.ts
+++ b/src/after.ts
@@ -2,6 +2,11 @@ import after = require('lodash/after');
 
 import { DecoratorConfig, DecoratorFactory, LodashDecorator } from './factory';
 import { PostValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createInstanceDecorator(
+  new DecoratorConfig(after, new PostValueApplicator(), { setter: true })
+);
+
 /**
  * The opposite of Before. This method creates a function that invokes once it's called n or more times.
  * @param {number} n The number of calls before the function is invoked.
@@ -19,8 +24,8 @@ import { PostValueApplicator } from './applicators';
  * myClass.fn(); // => undefined
  * myClass.fn(); // => 10
  */
-export const After: (n: number) => LodashDecorator = DecoratorFactory.createInstanceDecorator(
-  new DecoratorConfig(after, new PostValueApplicator(), { setter: true })
-);
+export function After(n: number): LodashDecorator {
+  return decorator(n);
+}
 export { After as after };
-export default After;
+export default decorator;

--- a/src/afterAll.ts
+++ b/src/afterAll.ts
@@ -2,6 +2,11 @@ import after = require('lodash/after');
 
 import { DecoratorConfig, DecoratorFactory, LodashDecorator } from './factory';
 import { PostValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(after, new PostValueApplicator(), { setter: true })
+);
+
 /**
  * The opposite of Before. This method creates a function that invokes once it's called n or more times.
  * This spans across all instances of the class instead of the instance.
@@ -24,8 +29,8 @@ import { PostValueApplicator } from './applicators';
  * myClass2.fn(); // => 10
  * myClass2.fn(); // => 10
  */
-export const AfterAll: (n: number) => LodashDecorator = DecoratorFactory.createDecorator(
-  new DecoratorConfig(after, new PostValueApplicator(), { setter: true })
-);
+export function AfterAll(n: number): LodashDecorator {
+  return decorator(n);
+}
 export { AfterAll as afterAll };
-export default AfterAll;
+export default decorator;

--- a/src/ary.ts
+++ b/src/ary.ts
@@ -2,6 +2,11 @@ import ary = require('lodash/ary');
 
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(ary, new PreValueApplicator())
+);
+
 /**
  * Creates a function that invokes func, with up to n arguments, ignoring any additional arguments.
  * @param {number} n The arity cap.
@@ -18,8 +23,8 @@ import { PreValueApplicator } from './applicators';
  *
  * myClass.fn(1, 2, 3, 4); // => [ 1 ]
  */
-export const Ary: (n: number) => LodashMethodDecorator = DecoratorFactory.createDecorator(
-  new DecoratorConfig(ary, new PreValueApplicator())
-);
+export function Ary(n: number): LodashMethodDecorator {
+  return decorator(n);
+}
 export { Ary as ary };
-export default Ary;
+export default decorator;

--- a/src/attempt.ts
+++ b/src/attempt.ts
@@ -5,6 +5,10 @@ import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './fact
 import { PreValueApplicator } from './applicators';
 
 const attemptFn = (fn: () => void) => partial(attempt, fn);
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(attemptFn, new PreValueApplicator())
+);
+
 /**
  * Attempts to invoke func, returning either the result or the caught error object. Any additional arguments are provided to func when it's invoked.
  * @param {...*} [args] The arguments to invoke func with.
@@ -26,8 +30,8 @@ const attemptFn = (fn: () => void) => partial(attempt, fn);
  * myClass.fn(10); // => 10;
  * myClass.fn(null); // => Error
  */
-export const Attempt: (...partials: any[]) => LodashMethodDecorator = DecoratorFactory.createDecorator(
-  new DecoratorConfig(attemptFn, new PreValueApplicator())
-);
+export function Attempt(...partials: any[]): LodashMethodDecorator {
+  return decorator(...partials);
+}
 export { Attempt as attempt };
-export default Attempt;
+export default decorator;

--- a/src/before.ts
+++ b/src/before.ts
@@ -2,6 +2,11 @@ import before = require('lodash/before');
 
 import { DecoratorConfig, DecoratorFactory, LodashDecorator } from './factory';
 import { PostValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createInstanceDecorator(
+  new DecoratorConfig(before, new PostValueApplicator(), { setter: true })
+);
+
 /**
  * Creates a function that invokes func, with the this binding and arguments of the created function, while it's called less than n times.
  * Subsequent calls to the created function return the result of the last func invocation.
@@ -26,8 +31,8 @@ import { PostValueApplicator } from './applicators';
  *
  * calls === 2; // => true
  */
-export const Before: (n: number) => LodashDecorator = DecoratorFactory.createInstanceDecorator(
-  new DecoratorConfig(before, new PostValueApplicator(), { setter: true })
-);
+export function Before(n: number): LodashDecorator {
+  return decorator(n);
+}
 export { Before as before };
-export default Before;
+export default decorator;

--- a/src/beforeAll.ts
+++ b/src/beforeAll.ts
@@ -2,6 +2,11 @@ import before = require('lodash/before');
 
 import { DecoratorConfig, DecoratorFactory, LodashDecorator } from './factory';
 import { PostValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(before, new PostValueApplicator(), { setter: true })
+);
+
 /**
  * Creates a function that invokes func, with the this binding and arguments of the created function, while it's called less than n times.
  * Subsequent calls to the created function return the result of the last func invocation.
@@ -29,8 +34,8 @@ import { PostValueApplicator } from './applicators';
  *
  * calls === 3; // => true
  */
-export const BeforeAll: (n: number) => LodashDecorator = DecoratorFactory.createDecorator(
-  new DecoratorConfig(before, new PostValueApplicator(), { setter: true })
-);
+export function BeforeAll(n: number): LodashDecorator {
+  return decorator(n);
+}
 export { BeforeAll as beforeAll };
-export default BeforeAll;
+export default decorator;

--- a/src/bind.ts
+++ b/src/bind.ts
@@ -2,6 +2,11 @@ import bind = require('lodash/bind');
 
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { BindApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createInstanceDecorator(
+  new DecoratorConfig(bind, new BindApplicator())
+);
+
 /**
  * Creates a function that invokes func with the this binding of thisArg and partials prepended to the arguments it receives.
  *
@@ -27,8 +32,8 @@ import { BindApplicator } from './applicators';
  * myClass.bound.call(null); // => myClass {}
  * myClass.unbound.call(null); // => null
  */
-export const Bind: (...partials: any[]) => LodashMethodDecorator = DecoratorFactory.createInstanceDecorator(
-  new DecoratorConfig(bind, new BindApplicator())
-);
+export function Bind(...partials: any[]): LodashMethodDecorator {
+  return decorator(...partials);
+}
 export { Bind as bind };
-export default Bind;
+export default decorator;

--- a/src/curry.ts
+++ b/src/curry.ts
@@ -2,6 +2,11 @@ import curry = require('lodash/curry');
 
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createInstanceDecorator(
+  new DecoratorConfig(curry, new PreValueApplicator(), { bound: true })
+);
+
 /**
  * Creates a function that accepts arguments of func and either invokes func returning its result, if at least arity number of arguments have been provided, or returns a function that accepts the remaining func arguments, and so on.
  * The arity of func may be specified if func.length is not sufficient.
@@ -28,8 +33,8 @@ import { PreValueApplicator } from './applicators';
  *
  * add5AndMultiply(10); // => 30
  */
-export const Curry: (arity?: number) => LodashMethodDecorator = DecoratorFactory.createInstanceDecorator(
-  new DecoratorConfig(curry, new PreValueApplicator(), { bound: true })
-);
+export function Curry(arity?: number): LodashMethodDecorator {
+  return decorator(arity);
+}
 export { Curry as curry };
-export default Curry;
+export default decorator;

--- a/src/curryAll.ts
+++ b/src/curryAll.ts
@@ -2,6 +2,11 @@ import curry = require('lodash/curry');
 
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(curry, new PreValueApplicator())
+);
+
 /**
  * Creates a function that accepts arguments of func and either invokes func returning its result, if at least arity number of arguments have been provided, or returns a function that accepts the remaining func arguments, and so on.
  * The arity of func may be specified if func.length is not sufficient.
@@ -26,8 +31,8 @@ import { PreValueApplicator } from './applicators';
  *
  * add5AndMultiply(10); // => 15
  */
-export const CurryAll: (arity?: number) => LodashMethodDecorator = DecoratorFactory.createDecorator(
-  new DecoratorConfig(curry, new PreValueApplicator())
-);
+export function CurryAll(arity?: number): LodashMethodDecorator {
+  return decorator(arity);
+}
 export { CurryAll as curryAll };
-export default CurryAll;
+export default decorator;

--- a/src/curryRight.ts
+++ b/src/curryRight.ts
@@ -2,6 +2,11 @@ import curryRight = require('lodash/curryRight');
 
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createInstanceDecorator(
+  new DecoratorConfig(curryRight, new PreValueApplicator(), { bound: true })
+);
+
 /**
  * This method is like _.curry except that arguments are applied to func in the manner of _.partialRight instead of _.partial.
  * The arity of func may be specified if func.length is not sufficient.
@@ -28,8 +33,8 @@ import { PreValueApplicator } from './applicators';
  *
  * add5AndMultiply(10); // => 30
  */
-export const CurryRight: (arity?: number) => LodashMethodDecorator = DecoratorFactory.createInstanceDecorator(
-  new DecoratorConfig(curryRight, new PreValueApplicator(), { bound: true })
-);
+export function CurryRight(arity?: number): LodashMethodDecorator {
+  return decorator(arity);
+}
 export { CurryRight as curryRight };
-export default CurryRight;
+export default decorator;

--- a/src/curryRightAll.ts
+++ b/src/curryRightAll.ts
@@ -2,6 +2,11 @@ import curryRight = require('lodash/curryRight');
 
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(curryRight, new PreValueApplicator())
+);
+
 /**
  * This method is like _.curry except that arguments are applied to func in the manner of _.partialRight instead of _.partial.
  * The arity of func may be specified if func.length is not sufficient.
@@ -26,8 +31,8 @@ import { PreValueApplicator } from './applicators';
  *
  * add5AndMultiply(10); // => 15
  */
-export const CurryRightAll: (arity?: number) => LodashMethodDecorator = DecoratorFactory.createDecorator(
-  new DecoratorConfig(curryRight, new PreValueApplicator())
-);
+export function CurryRightAll(arity?: number): LodashMethodDecorator {
+  return decorator(arity);
+}
 export { CurryRightAll as curryRightAll };
-export default CurryRightAll;
+export default decorator;

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -3,6 +3,11 @@ import debounce = require('lodash/debounce');
 import { DecoratorConfig, DecoratorFactory, LodashDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
 import { DebounceOptions } from './shared';
+
+const decorator = DecoratorFactory.createInstanceDecorator(
+  new DecoratorConfig(debounce, new PreValueApplicator(), { setter: true })
+);
+
 /**
  * Creates a debounced function that delays invoking func until after wait milliseconds have elapsed since the last time the debounced function was invoked.
  * The debounced function comes with a cancel method to cancel delayed func invocations and a flush method to immediately invoke them.
@@ -38,9 +43,8 @@ import { DebounceOptions } from './shared';
  *   myClass.value; // => 120;
  * }, 11);
  */
-export const Debounce: (wait?: number, options?: DebounceOptions) => LodashDecorator = DecoratorFactory.createInstanceDecorator(
-  new DecoratorConfig(debounce, new PreValueApplicator(), { setter: true })
-);
-
+export function Debounce(wait?: number, options?: DebounceOptions): LodashDecorator {
+  return decorator(wait, options);
+}
 export { Debounce as debounce };
-export default Debounce;
+export default decorator;

--- a/src/debounceAll.ts
+++ b/src/debounceAll.ts
@@ -3,6 +3,11 @@ import debounce = require('lodash/debounce');
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
 import { DebounceOptions } from './shared';
+
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(debounce, new PreValueApplicator())
+);
+
 /**
  * Creates a debounced function that delays invoking func until after wait milliseconds have elapsed since the last time the debounced function was invoked.
  * The debounced function comes with a cancel method to cancel delayed func invocations and a flush method to immediately invoke them.
@@ -40,8 +45,8 @@ import { DebounceOptions } from './shared';
  *   myClass.value; // => 120;
  * }, 11);
  */
-export const DebounceAll: (wait?: number, options?: DebounceOptions) => LodashMethodDecorator = DecoratorFactory.createDecorator(
-  new DecoratorConfig(debounce, new PreValueApplicator())
-);
+export function DebounceAll(wait?: number, options?: DebounceOptions): LodashMethodDecorator {
+  return decorator(wait, options);
+}
 export { DebounceAll as debounceAll };
-export default DebounceAll;
+export default decorator;

--- a/src/defer.ts
+++ b/src/defer.ts
@@ -2,6 +2,11 @@ import defer = require('lodash/defer');
 
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { InvokeApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(defer, new InvokeApplicator(), { setter: true })
+);
+
 /**
  * Defers invoking the func until the current call stack has cleared. Any additional arguments are provided to func when it's invoked.
  *
@@ -27,8 +32,8 @@ import { InvokeApplicator } from './applicators';
  *   myClass.value; // => 110;
  * }, 0);
  */
-export const Defer: (...args: any[]) => LodashMethodDecorator = DecoratorFactory.createDecorator(
-  new DecoratorConfig(defer, new InvokeApplicator(), { setter: true })
-);
+export function Defer(...args: any[]): LodashMethodDecorator {
+  return decorator(...args);
+}
 export { Defer as defer };
-export default Defer;
+export default decorator;

--- a/src/delay.ts
+++ b/src/delay.ts
@@ -2,6 +2,19 @@ import delay = require('lodash/delay');
 
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(
+    function(value: Function, wait: number, ...args: any[]) {
+      return function(...invokeArgs: any[]): any {
+        return delay(value.bind(this), wait, ...invokeArgs, ...args);
+      };
+    },
+    new PreValueApplicator(),
+    { setter: true }
+  )
+);
+
 /**
  * Invokes func after wait milliseconds. Any additional arguments are provided to func when it's invoked.
  *
@@ -28,16 +41,8 @@ import { PreValueApplicator } from './applicators';
  *   myClass.value; // => 110;
  * }, 30);
  */
-export const Delay: (wait: number, ...args: any[]) => LodashMethodDecorator = DecoratorFactory.createDecorator(
-  new DecoratorConfig(
-    function(value: Function, wait: number, ...args: any[]) {
-      return function(...invokeArgs: any[]): any {
-        return delay(value.bind(this), wait, ...invokeArgs, ...args);
-      };
-    },
-    new PreValueApplicator(),
-    { setter: true }
-  )
-);
+export function Delay(wait: number, ...args: any[]): LodashMethodDecorator {
+  return decorator(wait, ...args);
+}
 export { Delay as delay };
-export default Delay;
+export default decorator;

--- a/src/flip.ts
+++ b/src/flip.ts
@@ -7,6 +7,11 @@ import {
   ResolvableFunction
 } from './factory';
 import { PartialValueApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createInstanceDecorator(
+  new DecoratorConfig(flip, new PartialValueApplicator(), { property: true })
+);
+
 /**
  * Creates a function that invokes func with arguments reversed. Honestly, there is probably not much
  * use for this decorator but maybe you will find one?
@@ -28,8 +33,8 @@ import { PartialValueApplicator } from './applicators';
  *
  * myClass.fn2(10, '20'); // => [ '20', 10 ]
  */
-export const Flip: (fn?: ResolvableFunction) => LodashDecorator = DecoratorFactory.createInstanceDecorator(
-  new DecoratorConfig(flip, new PartialValueApplicator(), { property: true })
-);
+export function Flip(fn?: ResolvableFunction): LodashDecorator {
+  return decorator(fn);
+}
 export { Flip as flip };
-export default Flip;
+export default decorator;

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -7,6 +7,11 @@ import {
   LodashDecorator
 } from './factory';
 import { ComposeApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createInstanceDecorator(
+  new DecoratorConfig(flow, new ComposeApplicator({ post: true }), { property: true })
+);
+
 /**
  * Creates a function that returns the result of invoking the given functions with the this binding of the created function,
  * where each successive invocation is supplied the return value of the previous.
@@ -28,8 +33,8 @@ import { ComposeApplicator } from './applicators';
  *
  * myClass.getUpperCaseName(); // => 'TED'
  */
-export const Flow: (...fns: ResolvableFunction[]) => LodashDecorator = DecoratorFactory.createInstanceDecorator(
-  new DecoratorConfig(flow, new ComposeApplicator({ post: true }), { property: true })
-);
+export function Flow(...fns: ResolvableFunction[]): LodashDecorator {
+  return decorator(...fns);
+}
 export { Flow as flow };
-export default Flow;
+export default decorator;

--- a/src/flowRight.ts
+++ b/src/flowRight.ts
@@ -7,6 +7,11 @@ import {
   ResolvableFunction
 } from './factory';
 import { ComposeApplicator } from './applicators';
+
+const decorator = DecoratorFactory.createInstanceDecorator(
+  new DecoratorConfig(flowRight, new ComposeApplicator({ post: false }), { property: true })
+);
+
 /**
  * Creates a function that returns the result of invoking the given functions with the this binding of the created function,
  * where each successive invocation is supplied the return value of the previous.
@@ -28,8 +33,8 @@ import { ComposeApplicator } from './applicators';
  *
  * myClass.getUpperCaseName(); // => 'TED'
  */
-export const FlowRight: (...fns: ResolvableFunction[]) => LodashDecorator = DecoratorFactory.createInstanceDecorator(
-  new DecoratorConfig(flowRight, new ComposeApplicator({ post: false }), { property: true })
-);
+export function FlowRight(...fns: ResolvableFunction[]): LodashDecorator {
+  return decorator(...fns);
+}
 export { FlowRight as flowRight };
-export default FlowRight;
+export default decorator;

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -8,6 +8,10 @@ import {
 } from './factory';
 import { MemoizeApplicator } from './applicators';
 import { MemoizeConfig } from './shared';
+
+const decorator = DecoratorFactory.createInstanceDecorator(
+  new DecoratorConfig(memoize, new MemoizeApplicator())
+);
 /**
  * Creates a function that memoizes the result of func. If resolver is provided,
  * it determines the cache key for storing the result based on the arguments provided to the memoized function.
@@ -32,8 +36,8 @@ import { MemoizeConfig } from './shared';
  *   }
  * }
  */
-export const Memoize: (resolver?: ResolvableFunction|MemoizeConfig<any, any>) => LodashMethodDecorator = DecoratorFactory.createInstanceDecorator(
-  new DecoratorConfig(memoize, new MemoizeApplicator())
-);
+export function Memoize(resolver?: ResolvableFunction | MemoizeConfig<any, any>): LodashMethodDecorator {
+  return decorator(resolver);
+}
 export { Memoize as memoize };
-export default Memoize;
+export default decorator;

--- a/src/memoizeAll.ts
+++ b/src/memoizeAll.ts
@@ -4,12 +4,16 @@ import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './fact
 import { MemoizeApplicator } from './applicators';
 import { MemoizeConfig } from './shared';
 
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(memoize, new MemoizeApplicator())
+);
+
 /**
  * Memoizes a function on the prototype instead of the instance. All instances of the class use the same memoize cache.
  * @param {Function} [resolver] Optional resolver
  */
-export const MemoizeAll: (resolver?: Function|MemoizeConfig<any, any>) => LodashMethodDecorator = DecoratorFactory.createDecorator(
-  new DecoratorConfig(memoize, new MemoizeApplicator())
-);
+export function MemoizeAll(resolver?: Function | MemoizeConfig<any, any>): LodashMethodDecorator {
+  return decorator(resolver);
+}
 export { MemoizeAll as memoizeAll };
-export default MemoizeAll;
+export default decorator;

--- a/src/negate.ts
+++ b/src/negate.ts
@@ -8,8 +8,12 @@ import {
 } from './factory';
 import { PartialValueApplicator } from './applicators';
 
-export const Negate: (fn?: ResolvableFunction) => LodashDecorator = DecoratorFactory.createInstanceDecorator(
+const decorator = DecoratorFactory.createInstanceDecorator(
   new DecoratorConfig(negate, new PartialValueApplicator(), { property: true })
 );
+
+export function Negate(fn?: ResolvableFunction): LodashDecorator {
+  return decorator(fn);
+}
 export { Negate as negate };
-export default Negate;
+export default decorator;

--- a/src/once.ts
+++ b/src/once.ts
@@ -3,8 +3,12 @@ import once = require('lodash/once');
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
 
-export const Once: () => LodashMethodDecorator = DecoratorFactory.createInstanceDecorator(
+const decorator = DecoratorFactory.createInstanceDecorator(
   new DecoratorConfig(once, new PreValueApplicator(), { setter: true })
 );
+
+export function Once(): LodashMethodDecorator {
+  return decorator();
+}
 export { Once as once };
-export default Once;
+export default decorator;

--- a/src/onceAll.ts
+++ b/src/onceAll.ts
@@ -1,8 +1,14 @@
 import once = require('lodash/once');
 
-import { DecoratorConfig, DecoratorFactory } from './factory';
+import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
 
-export const OnceAll = DecoratorFactory.createDecorator(new DecoratorConfig(once, new PreValueApplicator(), { setter: true }))();
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig(once, new PreValueApplicator(), { setter: true })
+);
+
+export function OnceAll(): LodashMethodDecorator {
+  return decorator();
+}
 export { OnceAll as onceAll };
-export default OnceAll;
+export default decorator;

--- a/src/overArgs.ts
+++ b/src/overArgs.ts
@@ -3,8 +3,11 @@ import overArgs = require('lodash/overArgs');
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
 
-export const OverArgs: (...transforms: Function[]) => LodashMethodDecorator = DecoratorFactory.createDecorator(
+const decorator = DecoratorFactory.createDecorator(
   new DecoratorConfig(overArgs, new PreValueApplicator(), { setter: true })
 );
+export function OverArgs(...transforms: Function[]): LodashMethodDecorator {
+  return decorator(...transforms);
+}
 export { OverArgs as overArgs };
-export default OverArgs;
+export default decorator;

--- a/src/partial.ts
+++ b/src/partial.ts
@@ -3,8 +3,11 @@ import partial = require('lodash/partial');
 import { DecoratorConfig, DecoratorFactory } from './factory';
 import { PartialApplicator } from './applicators';
 
-export const Partial: (...partials: any[]) => PropertyDecorator = DecoratorFactory.createInstanceDecorator(
+const decorator = DecoratorFactory.createInstanceDecorator(
   new DecoratorConfig(partial, new PartialApplicator(), { property: true, method: false })
 );
+export function Partial(...partials: any[]): PropertyDecorator {
+  return decorator(...partials);
+}
 export { Partial as partial };
-export default Partial;
+export default decorator;

--- a/src/partialRight.ts
+++ b/src/partialRight.ts
@@ -3,8 +3,11 @@ import partialRight = require('lodash/partialRight');
 import { DecoratorConfig, DecoratorFactory } from './factory';
 import { PartialApplicator } from './applicators';
 
-export const PartialRight: (...partials: any[]) => PropertyDecorator = DecoratorFactory.createInstanceDecorator(
+const decorator = DecoratorFactory.createInstanceDecorator(
   new DecoratorConfig(partialRight, new PartialApplicator(), { property: true, method: false })
 );
+export function PartialRight(...partials: any[]): PropertyDecorator {
+  return decorator(...partials);
+}
 export { PartialRight as partialRight };
-export default PartialRight;
+export default decorator;

--- a/src/rearg.ts
+++ b/src/rearg.ts
@@ -8,8 +8,12 @@ import {
 } from './factory';
 import { PartialValueApplicator } from './applicators';
 
-export const Rearg: (indexes: ResolvableFunction|number|number[], ...args: Array<number|number[]>) => LodashDecorator = DecoratorFactory.createInstanceDecorator(
+const decorator = DecoratorFactory.createInstanceDecorator(
   new DecoratorConfig(rearg, new PartialValueApplicator(), { property: true })
 );
+
+export function Rearg(indexes: ResolvableFunction | number | number[], ...args: Array<number | number[]>): LodashDecorator {
+  return decorator(indexes, ...args);
+}
 export { Rearg as rearg };
-export default Rearg;
+export default decorator;

--- a/src/rest.ts
+++ b/src/rest.ts
@@ -3,8 +3,11 @@ import rest = require('lodash/rest');
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
 
-export const Rest: (start?: number) => LodashMethodDecorator = DecoratorFactory.createDecorator(
+const decorator = DecoratorFactory.createDecorator(
   new DecoratorConfig(rest, new PreValueApplicator())
 );
+export function Rest(start?: number): LodashMethodDecorator {
+  return decorator(start);
+}
 export { Rest as rest };
-export default Rest;
+export default decorator;

--- a/src/spread.ts
+++ b/src/spread.ts
@@ -3,8 +3,11 @@ import spread = require('lodash/spread');
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
 
-export const Spread: (start?: number) => LodashMethodDecorator = DecoratorFactory.createDecorator(
+const decorator = DecoratorFactory.createDecorator(
   new DecoratorConfig(spread, new PreValueApplicator())
 );
+export function Spread(start?: number): LodashMethodDecorator {
+  return decorator(start);
+}
 export { Spread as spread };
-export default Spread;
+export default decorator;

--- a/src/tap.ts
+++ b/src/tap.ts
@@ -2,12 +2,16 @@ import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './fact
 import { PreValueApplicator } from './applicators';
 import { returnAtIndex } from './utils';
 
+const decorator = DecoratorFactory.createDecorator(
+  new DecoratorConfig((fn: Function) => returnAtIndex(fn, 0), new PreValueApplicator())
+);
+
 /**
  * Returns the first argument from the function regardless of
  * the decorated functions return value.
  */
-export const Tap: () => LodashMethodDecorator  = DecoratorFactory.createDecorator(
-  new DecoratorConfig((fn: Function) => returnAtIndex(fn, 0), new PreValueApplicator())
-);
+export function Tap(): LodashMethodDecorator {
+  return decorator();
+}
 export { Tap as tap };
-export default Tap;
+export default decorator;

--- a/src/throttle.ts
+++ b/src/throttle.ts
@@ -4,19 +4,28 @@ import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './fact
 import { PreValueApplicator } from './applicators';
 import { ThrottleOptions } from './shared';
 
-export const Throttle: (wait?: number, options?: ThrottleOptions) => LodashMethodDecorator = DecoratorFactory.createInstanceDecorator(
+const decorator = DecoratorFactory.createInstanceDecorator(
   new DecoratorConfig(throttle, new PreValueApplicator(), { setter: true, getter: true })
 );
+export function Throttle(wait?: number, options?: ThrottleOptions): LodashMethodDecorator {
+  return decorator(wait, options);
+}
 
-export const ThrottleGetter: (wait?: number, options?: ThrottleOptions) => LodashMethodDecorator = DecoratorFactory.createInstanceDecorator(
+const decoratorGetter = DecoratorFactory.createInstanceDecorator(
   new DecoratorConfig(throttle, new PreValueApplicator(), { getter: true })
 );
+export function ThrottleGetter(wait?: number, options?: ThrottleOptions): LodashMethodDecorator {
+  return decoratorGetter(wait, options);
+}
 
-export const ThrottleSetter: (wait?: number, options?: ThrottleOptions) => LodashMethodDecorator = DecoratorFactory.createInstanceDecorator(
+const decoratorSetter = DecoratorFactory.createInstanceDecorator(
   new DecoratorConfig(throttle, new PreValueApplicator(), { setter: true })
 );
+export function ThrottleSetter(wait?: number, options?: ThrottleOptions): LodashMethodDecorator {
+  return decoratorSetter(wait, options);
+}
 
 export { Throttle as throttle };
 export { ThrottleGetter as throttleGetter };
 export { ThrottleSetter as throttleSetter };
-export default Throttle;
+export default decorator;

--- a/src/throttleAll.ts
+++ b/src/throttleAll.ts
@@ -4,8 +4,11 @@ import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './fact
 import { PreValueApplicator } from './applicators';
 import { ThrottleOptions } from './shared';
 
-export const ThrottleAll: (wait?: number, options?: ThrottleOptions) => LodashMethodDecorator = DecoratorFactory.createDecorator(
+const decorator = DecoratorFactory.createDecorator(
   new DecoratorConfig(throttle, new PreValueApplicator(), { setter: true })
 );
+export function ThrottleAll(wait?: number, options?: ThrottleOptions): LodashMethodDecorator {
+  return decorator(wait, options);
+}
 export { ThrottleAll as throttleAll };
-export default ThrottleAll;
+export default decorator;

--- a/src/unary.ts
+++ b/src/unary.ts
@@ -3,8 +3,11 @@ import unary = require('lodash/unary');
 import { DecoratorConfig, DecoratorFactory, LodashMethodDecorator } from './factory';
 import { PreValueApplicator } from './applicators';
 
-export const Unary: () => LodashMethodDecorator = DecoratorFactory.createDecorator(
+const decorator = DecoratorFactory.createDecorator(
   new DecoratorConfig(unary, new PreValueApplicator())
 );
+export function Unary(): LodashMethodDecorator {
+  return decorator();
+}
 export { Unary as unary };
-export default Unary;
+export default decorator;

--- a/src/wrap.ts
+++ b/src/wrap.ts
@@ -8,8 +8,11 @@ import {
 } from './factory';
 import { WrapApplicator } from './applicators';
 
-export const Wrap: (fnToWrap?: ResolvableFunction) => LodashMethodDecorator = DecoratorFactory.createDecorator(
+const decorator = DecoratorFactory.createDecorator(
   new DecoratorConfig(wrap, new WrapApplicator())
 );
+export function Wrap(fnToWrap?: ResolvableFunction): LodashMethodDecorator {
+  return decorator(fnToWrap);
+}
 export { Wrap as wrap };
-export default Wrap;
+export default decorator;


### PR DESCRIPTION
In order for Angular AOT to work, method decorators must be pure functions.

Fixes: #27

