### PR TITLE
feat(*): inline source code in sourceMaps rather than shipping it

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+src
 test
 docs
 buildDocs

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "target": "es5",
     "strictNullChecks": true,
     "noImplicitAny": true,


### PR DESCRIPTION
Don't ship the sourcecode, rather emit the source in the sourcemap.

Emit the source alongside the sourcemaps within a single file; requires --inlineSourceMap or --sourceMap to be set.

https://www.typescriptlang.org/docs/handbook/compiler-options.html