### PR TITLE
fix(BindAll): Copy original function name to wrapper

### DIFF
--- a/src/utils/wrapConstructor.ts
+++ b/src/utils/wrapConstructor.ts
@@ -22,6 +22,8 @@ export function wrapConstructor(Ctor: Function, wrapper: (Ctor: Function, ...arg
   }
 
   ConstructorWrapper.prototype = Ctor.prototype;
+  Object.defineProperty(ConstructorWrapper, 'name', { writable: true });
+  (ConstructorWrapper as any).name = Ctor.name;
 
   return assignAll(ConstructorWrapper, Ctor, PROPERTY_EXCLUDES);
 }


### PR DESCRIPTION
Restores function names for use in debugging

For example, we use BindAll heavily in a react project.  

## The React dev tools look like this today:

![screen shot 2017-11-02 at 4 03 54 pm](https://user-images.githubusercontent.com/2053478/32354619-b9598446-bfe7-11e7-9eec-eed24e53af6a.png)


## And with this PR they look like this: 

![screen shot 2017-11-02 at 4 05 40 pm](https://user-images.githubusercontent.com/2053478/32354628-c4606cec-bfe7-11e7-9354-a9706ffd6399.png)
