### PR TITLE
fix: isPrototypeAccess get prototype from `context` instead of `this`

### DIFF
--- a/src/utils/isPrototypeAccess.ts
+++ b/src/utils/isPrototypeAccess.ts
@@ -1,5 +1,5 @@
 export function isPrototypeAccess(context: object, target: object): boolean {
   return context === target
     || (context.constructor !== target.constructor
-      && Object.getPrototypeOf(this).constructor === target.constructor);
+      && Object.getPrototypeOf(context).constructor === target.constructor);
 }


### PR DESCRIPTION
Apply fix mentionned in #58 